### PR TITLE
fix: the "name"-part of a MailAddress gets quoted multiple times

### DIFF
--- a/src/Mail/Client/Data/MailAddress.php
+++ b/src/Mail/Client/Data/MailAddress.php
@@ -83,7 +83,7 @@ class MailAddress implements Stringable, JsonDecodable, Copyable, Jsonable
             throw new InvalidArgumentException("\"address\" must be set for a MailAddress");
         }
         $this->address = $address;
-        $this->name = $this->escapeName($name);
+        $this->name = $name;
     }
 
 
@@ -150,7 +150,7 @@ class MailAddress implements Stringable, JsonDecodable, Copyable, Jsonable
         }
 
         $address = $val["address"];
-        $name = $val["name"] ?? $val["address"];
+        $name = isset($val["name"]) ? self::escapeName($val["name"]) : $val["address"];
 
         try {
             return new self($address, $name);
@@ -200,7 +200,6 @@ class MailAddress implements Stringable, JsonDecodable, Copyable, Jsonable
      */
     public function toJson(JsonStrategy $strategy = null): array
     {
-
         return [
             'address' => $this->getAddress(),
             'name' => $this->getName()
@@ -208,12 +207,12 @@ class MailAddress implements Stringable, JsonDecodable, Copyable, Jsonable
     }
 
 
-    private function escapeName(string $name): string
+    private static function escapeName(string $name): string
     {
         $regex = '/(,|"|\')/m';
 
         if (preg_match($regex, $name) === 1) {
-            return "\"" . addslashes($name) . "\"";
+            return  '"'.addslashes($name).'"' ;
         }
         return $name;
     }

--- a/tests/Mail/Client/Data/MailAddressTest.php
+++ b/tests/Mail/Client/Data/MailAddressTest.php
@@ -111,6 +111,59 @@ class MailAddressTest extends TestCase
     public function testFromString()
     {
 
+        /**
+         * @see conjoon/php-lib-conjoon#12
+         */
+        $tests = [
+            [
+                ["Peter, Parker", "peter.parker@newyork.com"],
+                ["\"Peter, Parker\"", "peter.parker@newyork.com"]
+            ],
+            [
+                ["Parker Peter", "peter.parker@newyork.com"],
+                ["Parker Peter", "peter.parker@newyork.com"],
+            ],
+            [
+                ["Parker \" Peter", "peter.parker@newyork.com"],
+                ["\"Parker \\\" Peter\"", "peter.parker@newyork.com"],
+            ],
+            [
+                ["Parker ' Peter", "peter.parker@newyork.com"],
+                ["\"Parker \' Peter\"", "peter.parker@newyork.com"],
+            ],
+            [
+                ["Parker \"Parker, Peter Peter", "peter.parker@newyork.com"],
+                ["\"Parker \\\"Parker, Peter Peter\"", "peter.parker@newyork.com"],
+            ],
+            [
+                ["Schäfer, Peter", "pschaefer@tld.tld.de"],
+                ["\"Schäfer, Peter\"", "pschaefer@tld.tld.de"]
+            ],
+            [
+                ['"Schäfer, Peter"', "pschaefer@tld.tld.de"],
+                ['"\"Schäfer, Peter\""', "pschaefer@tld.tld.de"]
+            ],
+            [
+                ['"Schä"fer, Pe"ter"', "pschaefer@tld.tld.de"],
+                ['"\"Schä\"fer, Pe\"ter\""', "pschaefer@tld.tld.de"]
+            ]
+
+        ];
+
+        foreach ($tests as $test) {
+            [$input, $output] = $test;
+
+            $mailAddress = new MailAddress($input[1], $input[0]);
+
+            $jsonString = json_encode($mailAddress->toJson());
+            $fromStringMailAddress = MailAddress::fromString($jsonString);
+
+            $this->assertSame($output[1], $fromStringMailAddress->getAddress());
+            $this->assertSame($output[0], $fromStringMailAddress->getName());
+        }
+
+
+
         $name = "Peter Parker";
         $address = "peter.parker@newyork.com";
         $mailAddress = new MailAddress($address, $name);
@@ -166,39 +219,4 @@ class MailAddressTest extends TestCase
     }
 
 
-    /**
-     * @see conjoon/php-lib-conjoon#12
-     */
-    public function testForAddressThatNeedToBeSanitized()
-    {
-        $tests = [
-            [
-                ["Parker, Peter", "peter.parker@newyork.com"],
-                ["\"Parker, Peter\"", "peter.parker@newyork.com"],
-            ],
-            [
-                ["Parker Peter", "peter.parker@newyork.com"],
-                ["Parker Peter", "peter.parker@newyork.com"],
-            ],
-            [
-                ["Parker \" Peter", "peter.parker@newyork.com"],
-                ["\"Parker \\\" Peter\"", "peter.parker@newyork.com"],
-            ],
-            [
-                ["Parker ' Peter", "peter.parker@newyork.com"],
-                ["\"Parker \' Peter\"", "peter.parker@newyork.com"],
-            ],
-            [
-                ["Parker \"Parker, Peter Peter", "peter.parker@newyork.com"],
-                ["\"Parker \\\"Parker, Peter Peter\"", "peter.parker@newyork.com"],
-            ]
-        ];
-
-        foreach ($tests as $test) {
-            [$input, $output] = $test;
-            $mailAddress = new MailAddress($input[1], $input[0]);
-            $this->assertSame($output[1], $mailAddress->getAddress());
-            $this->assertSame($output[0], $mailAddress->getName());
-        }
-    }
 }


### PR DESCRIPTION
refs conjoon/php-lib-conjoon#18